### PR TITLE
Get project tickets

### DIFF
--- a/src/actions/getProjectTicketsAction.test.ts
+++ b/src/actions/getProjectTicketsAction.test.ts
@@ -1,0 +1,98 @@
+import createTicketAction from "./createTicketAction";
+import { PrismaClient } from "@prisma/client";
+import createProjectAction from "./createProjectAction";
+import createStatusAction from "./createStatusAction";
+import createUserAction from "./createUserAction";
+import deleteTicketAction from "./deleteTicketAction";
+import getProjectTickets from "./getProjectTicketsAction";
+const faker = require("@faker-js/faker");
+
+const prisma = new PrismaClient();
+afterAll(() => {
+  return expect(prisma.$disconnect()).resolves;
+});
+
+describe("project tickets action - unit", () => {
+  it("get ticket from an existing project", async () => {
+    const name = faker.git.commitMessage();
+    const description = faker.random.words(10);
+    const createdAt = faker.date.recent();
+
+    const savedProject = await createProjectAction({
+      prisma,
+      name: faker.internet.domainName(),
+      description: faker.random.words(10),
+      createdAt: faker.date.recent(),
+      estimateEndAt: faker.date.future(),
+    });
+
+    const savedStatus = await createStatusAction({
+      prisma,
+      name: faker.random.word(),
+    });
+
+    const savedAssignee = await createUserAction({
+      prisma,
+      profilePicture: faker.image.people(500, 500),
+      firstName: faker.name.firstName(),
+      lastName: faker.name.lastName(),
+      email: faker.internet.email(),
+      password: faker.internet.password(),
+    });
+
+    const projectId = savedProject.id;
+    const statusId = savedStatus.id;
+    const assigneeId = savedAssignee.id;
+
+    const savedTicket = await createTicketAction({
+      prisma,
+      name,
+      description,
+      projectId,
+      statusId,
+      assigneeId,
+      createdAt,
+    });
+
+    const projectTickets = await getProjectTickets({
+      prisma,
+      projectId,
+    });
+
+    expect(projectTickets).toBeTruthy();
+    expect(projectTickets).toHaveLength(1);
+    expect(projectTickets).toEqual(expect.arrayContaining([savedTicket]));
+  });
+
+  it("get an empty array from an existing project", async () => {
+    const savedProject = await createProjectAction({
+      prisma,
+      name: faker.internet.domainName(),
+      description: faker.random.words(10),
+      createdAt: faker.date.recent(),
+      estimateEndAt: faker.date.future(),
+    });
+
+    const projectId = savedProject.id;
+
+    const projectTickets = await getProjectTickets({
+      prisma,
+      projectId,
+    });
+
+    expect(projectTickets).toBeTruthy();
+    expect(projectTickets).toHaveLength(0);
+    expect(projectTickets).toEqual([]);
+  });
+
+  it("get null from a non-existing project", async () => {
+    const projectId = faker.mersenne.rand(100000000, 999999999);
+
+    const projectTickets = await getProjectTickets({
+      prisma,
+      projectId,
+    });
+
+    expect(projectTickets).toBeNull();
+  });
+});

--- a/src/actions/getProjectTicketsAction.ts
+++ b/src/actions/getProjectTicketsAction.ts
@@ -1,0 +1,25 @@
+import { PrismaClient, Ticket } from "@prisma/client";
+
+export interface ProjectTicketsActionParams {
+  prisma: PrismaClient;
+  projectId: number;
+}
+
+const getProjectTickets = async ({
+  prisma,
+  projectId,
+}: ProjectTicketsActionParams): Promise<Ticket[] | [] | null> => {
+  const isProjectExists = await prisma.project.findUnique({
+    where: { id: projectId },
+  });
+
+  if (!isProjectExists) {
+    return null;
+  }
+
+  return await prisma.ticket.findMany({
+    where: { projectId: projectId },
+  });
+};
+
+export default getProjectTickets;

--- a/src/models/Ticket.ts
+++ b/src/models/Ticket.ts
@@ -14,7 +14,7 @@ export class Ticket {
   @Field(() => Date)
   createdAt!: Date;
 
-  @Field(() => Date)
+  @Field(() => Date, { nullable: true })
   finishedAt!: Date | null;
 
   @Field(() => Int)

--- a/src/repositories/ticketsRepository.ts
+++ b/src/repositories/ticketsRepository.ts
@@ -29,6 +29,24 @@ const ticketsRepository = {
 
     return ticketId;
   },
+
+  getProjectTickets: async (
+    projectId: number
+  ): Promise<Ticket[] | [] | null> => {
+    const isProjectExists = await prisma.project.findUnique({
+      where: { id: projectId },
+    });
+
+    if (!isProjectExists) {
+      return null;
+    }
+
+    return prisma.ticket.findMany({
+      where: {
+        projectId: projectId,
+      },
+    });
+  },
 };
 
 export default ticketsRepository;

--- a/src/resolvers/TicketResolver.spec.ts
+++ b/src/resolvers/TicketResolver.spec.ts
@@ -49,4 +49,25 @@ describe("ticket resolver", () => {
       ticketId: 1,
     };
   });
+
+  describe("get project tickets query", () => {
+    it("retrieve tickets from a project in db", async () => {
+      const projectTicketsQuery = gql`
+        query Query($projectId: Float!) {
+          getProjectTickets(projectId: $projectId) {
+            name
+            createdAt
+            description
+            projectId
+            statusId
+            assigneeId
+            finishedAt
+          }
+        }
+      `;
+    });
+    const variables = {
+      projectId: 1,
+    };
+  });
 });

--- a/src/resolvers/TicketResolver.ts
+++ b/src/resolvers/TicketResolver.ts
@@ -1,4 +1,4 @@
-import { Arg, Mutation, Resolver } from "type-graphql";
+import { Arg, Mutation, Query, Resolver } from "type-graphql";
 import { TicketInput } from "../inputs/TicketInput";
 import { Ticket } from "../models/Ticket";
 import ticketService from "../services/ticketsService";
@@ -13,5 +13,10 @@ export class TicketResolver {
   @Mutation(() => Number)
   async deleteTicket(@Arg("ticketId") ticketId: number) {
     return await ticketService.delete(ticketId);
+  }
+
+  @Query(() => [Ticket])
+  async getProjectTickets(@Arg("projectId") projectId: number) {
+    return await ticketService.getProjectTickets(projectId);
   }
 }

--- a/src/services/ticketService.spec.ts
+++ b/src/services/ticketService.spec.ts
@@ -3,6 +3,8 @@ import createUserAction from "../actions/createUserAction";
 import createProjectAction from "../actions/createProjectAction";
 import createStatusAction from "../actions/createStatusAction";
 import ticketService from "./ticketsService";
+import getProjectTickets from "../actions/getProjectTicketsAction";
+import createTicketAction from "../actions/createTicketAction";
 const faker = require("@faker-js/faker");
 
 const prisma = new PrismaClient();
@@ -99,5 +101,77 @@ describe("ticketService", () => {
     });
 
     expect(deletedTicket).toBeNull();
+  });
+
+  it("get project tickets correctly", async () => {
+    const savedUser = await createUserAction({
+      prisma,
+      profilePicture: faker.image.people(500, 500),
+      firstName: faker.name.firstName(),
+      lastName: faker.name.lastName(),
+      email: faker.internet.email(),
+      password: faker.internet.password(),
+    });
+
+    const savedProject = await createProjectAction({
+      prisma,
+      name: faker.internet.domainName(),
+      description: faker.random.words(10),
+      createdAt: faker.date.recent(),
+      estimateEndAt: faker.date.future(),
+    });
+
+    const savedStatus = await createStatusAction({
+      prisma,
+      name: faker.random.word(),
+    });
+
+    const name = faker.git.commitMessage();
+    const description = faker.random.words(10);
+    const createdAt = faker.date.recent();
+
+    const savedTicket = await createTicketAction({
+      prisma,
+      name,
+      description,
+      projectId: savedProject.id,
+      statusId: savedStatus.id,
+      assigneeId: savedUser.id,
+      createdAt,
+    });
+
+    const projectTickets = await ticketService.getProjectTickets(
+      savedProject.id
+    );
+
+    expect(projectTickets).toBeTruthy();
+    expect(projectTickets).toHaveLength(1);
+    expect(projectTickets).toEqual(expect.arrayContaining([savedTicket]));
+  });
+
+  it("get an empty array from an existing project", async () => {
+    const savedProject = await createProjectAction({
+      prisma,
+      name: faker.internet.domainName(),
+      description: faker.random.words(10),
+      createdAt: faker.date.recent(),
+      estimateEndAt: faker.date.future(),
+    });
+
+    const projectId = savedProject.id;
+    const projectTickets = await ticketService.getProjectTickets(projectId);
+
+    expect(projectTickets).toBeTruthy();
+    expect(projectTickets).toHaveLength(0);
+    expect(projectTickets).toEqual([]);
+  });
+
+  it("throw an error from a non-existing project", async () => {
+    const projectId = faker.mersenne.rand(100000000, 999999999);
+    const projectTicketsPromise = ticketService.getProjectTickets(projectId);
+
+    await expect(projectTicketsPromise).rejects.toThrow(
+      "Project doesn't exist"
+    );
   });
 });

--- a/src/services/ticketsService.ts
+++ b/src/services/ticketsService.ts
@@ -1,6 +1,8 @@
-import { Ticket } from "@prisma/client";
+import { Ticket, PrismaClient } from "@prisma/client";
 import { TicketInput } from "../inputs/TicketInput";
 import ticketsRepository from "../repositories/ticketsRepository";
+
+const prisma = new PrismaClient();
 
 const ticketService = {
   create: (ticketInput: TicketInput): Promise<Ticket> => {
@@ -27,6 +29,26 @@ const ticketService = {
     }
 
     return ticketsRepository.delete(ticketId);
+  },
+
+  getProjectTickets: async (projectId: number): Promise<Ticket[] | [] | null> => {
+    const isProjectExists = await prisma.project.findUnique({
+      where: { id: projectId },
+    });
+
+    if (!projectId) {
+      throw new Error("Project ID is required");
+    }
+
+    if (typeof projectId !== "number") {
+      throw new Error("Project ID must be a number");
+    }
+
+    if (!isProjectExists) {
+      throw new Error("Project doesn't exist");
+    }
+
+    return ticketsRepository.getProjectTickets(projectId);
   },
 };
 


### PR DESCRIPTION
Création de la Query `getProjectTickets` qui récupère les tickets d'un project :

- Si le projet existe et que un ou plusieurs tickets appartiennent à ce projet, on retourne un tableau d'objets
- Si le projet existe mais aucun ticket, on retourne un tableau vide
- Si le projet n'existe pas on throw une erreur (retourne null côté repo)